### PR TITLE
add camel-drools-blueprint example

### DIFF
--- a/assemblies/apache-servicemix/src/main/filtered-resources/features.xml
+++ b/assemblies/apache-servicemix/src/main/filtered-resources/features.xml
@@ -85,6 +85,11 @@
         <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.drools/${drools.bundle.version}</bundle>
         <bundle>mvn:org.apache.servicemix.examples/camel-drools/${version}</bundle>
     </feature>
+    <feature name="examples-camel-drools-blueprint" version="${version}" resolver="(obr)">
+        <feature version="${camel.version}">camel-jms</feature>
+        <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.drools/${drools.bundle.version}</bundle>
+        <bundle>mvn:org.apache.servicemix.examples/camel-drools-blueprint/${version}</bundle>
+    </feature>
     <feature name="examples-cxf-ws-addressing" version="${version}" resolver="(obr)">
         <feature version="${cxf.version}">cxf</feature>
         <bundle dependency="true">mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.jbi-api-1.0/${servicemix.specs.version}</bundle>

--- a/examples/camel/camel-drools-blueprint/README.txt
+++ b/examples/camel/camel-drools-blueprint/README.txt
@@ -1,0 +1,222 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+CAMEL DROOLS BLUEPRINT EXAMPLE
+==============================
+
+Purpose
+-------
+Deploys a Camel route in blueprint which allows a Drools rules file to
+evaluate messages and deliver each of them to a appropriate destination.
+
+
+Explanation
+-----------
+The Camel route is defined in a Blueprint XML file, blueprint.xml, which can be
+found in the src/main/resources/OSGI-INF/blueprint directory of this example.
+The route is defined in the <route> element and can be explained as follows:
+
+1. A timer endpoint generates a person every second
+
+2. A the Person object is send to a Drools grid-node which is connected to the Drools knowledge base
+
+3. After the object is evaluated, It's Vip-property is inspected
+
+4. Based on this value, one of the two log-messages is chosen to display the result.
+
+The camel-context.xml file also contains the following elements:
+
+- A call to the bean factory method createGridNode which replaces the <drools:grid-node />
+  implementation of the drools namespace handler for spring. This factory acts as a reference
+  to the Drools ruleset.
+
+- A call to the bean factory method createKnowledgeBase which replaces the <drools:kbase />
+  implementation of the drools namespace handler for spring. This factory creates an element
+  for the configuration of the knowledge base and the link to the DRL-rules file.
+
+- A call to the bean factory method createKnowledgeSession which replaces the <drools:ksession />
+  implementation of the drools namespace handler for spring. This factory creates en element
+  which constructs a session for the Drools evaluation.
+
+- A personHelper bean to generate random Person objects
+
+- the Drools camel component bean for our camel route.
+
+The route and configuration are deployed in an OSGi bundle.
+
+
+
+Embedded rules
+---------------
+rule "humans need water"
+     Every person gets water
+
+rule "boys go for Cola Zero"
+     Males older than 8 get Cola Zero
+
+rule "girls go for Cola Light"
+     Girls older than 8 get Cola Light
+
+rule "can you drink?"
+     A person older than 21 can drink alcohol
+
+rule "woman go for wine"
+     Woman who are allowed to drink, take wine
+
+rule "men go for beer"
+     Men who are allowed to drink, take beer
+
+rule "Vip in the house!"
+     Rich people are VIPs
+
+rule "Vip woman drink bubbles"
+     Female VIPs drink champagne
+
+rule "Vip men drink scotch"
+     Male VIPs drink scotch
+
+
+
+Prerequisites for Running the Example
+-------------------------------------
+1. You must have the following installed on your machine:
+
+   - JDK 1.6 or higher
+
+   - Maven 2.2.1 or higher (for building)
+
+  For more information, see the README in the top-level examples
+  directory.
+
+2. This example requires some additional configuration to allow
+   the JVM to use more PermGen memory:
+
+    export JAVA_MAX_PERM_MEM=128m             (on UNIX)
+    set JAVA_MAX_PERM_MEM=128m                (on Windows)
+
+
+3. Start ServiceMix by running the following command:
+
+    <servicemix_home>/bin/servicemix          (on UNIX)
+    <servicemix_home>\bin\servicemix          (on Windows)
+
+
+Running the Example
+-------------------
+You can run the example in two ways:
+
+- A. Using a Prebuilt Deployment Bundle: Quick and Easy
+  This option is useful if you want to see the example up and
+  running quickly.
+
+- B. Building the Example Bundle Yourself
+  This option is useful if you want to change the example in any way.
+  It tells you how to build and deploy the example. This option might
+  be slower than option A because, if you do not already have the
+  required bundles in your local Maven repository, Maven will have to
+  download the bundles it needs.
+
+
+A. Using a Prebuilt Deployment Bundle: Quick and Easy
+-----------------------------------------------------
+To install and run a prebuilt version of this example, enter the
+following command in the ServiceMix console:
+
+  features:install examples-camel-drools-blueprint
+
+This command makes use of the ServiceMix features facility. For more
+information about the features facility, see the README.txt file in the
+examples parent directory.
+
+Once the example is running, periodic events trigger the generation of
+a Person object and his evaluation. An object can either end up in the
+VIP log message or in a regular log message
+
+>>>> | ServeDrink     | ... | Serve this old man a pint of beer
+>>>> | ServeDrink VIP | ... | This old rich woman is a VIP! Give a bottle of champagne from the house
+
+
+B. Building the Example Bundle Yourself
+---------------------------------------
+To install and run the example where you build the example bundle
+yourself, complete the following steps:
+
+1. If you have already run the example using the prebuilt version as
+   described above, you must first uninstall the examples-camel-drools-blueprint
+   feature by entering the following command in the ServiceMix console:
+
+     features:uninstall examples-camel-drools-blueprint
+
+2. Build the example by opening a command prompt, changing directory to
+   examples/camel/camel-drools-blueprint (this example) and entering the
+   following Maven command:
+
+     mvn install
+
+   If all of the required OSGi bundles are available in your local Maven
+   repository, the example will build very quickly. Otherwise it may
+   take some time for Maven to download everything it needs.
+
+   The mvn install command builds the example deployment bundle and
+   copies it to your local Maven repository and to the target directory
+   of this example.
+
+3. Install the example by entering the following command in
+   the ServiceMix console:
+
+     features:install examples-camel-drools-blueprint
+
+   It makes use of the ServiceMix features facility. For more information
+   about the features facility, see the README.txt file in the examples
+   parent directory.
+
+Once the example is running, periodic events trigger the generation of
+a Person object and his evaluation. An object can either end up in the
+VIP log message or in a regular log message
+
+>>>> | ServeDrink     | ... | Serve this old man a pint of beer
+>>>> | ServeDrink VIP | ... | This old rich woman is a VIP! Give a bottle of champagne from the house
+
+
+Stopping and Uninstalling the Example
+-------------------------------------
+To stop the example, enter the following command in the ServiceMix
+console:
+
+  osgi:stop <bundle_id>
+
+For information on how to find the bundle_id assigned to the example,
+see step 3 in the "Updating and Redeploying the Properties File
+from the Console" section above.
+
+To uninstall the example, enter one of the following commands in
+the ServiceMix console:
+
+  features:uninstall examples-camel-drools-blueprint
+
+or
+
+  osgi:uninstall <bundle_id>
+
+
+Viewing the Log Entries
+-----------------------
+You can view the entries in the log file in the data/log
+directory of your ServiceMix installation, or by typing
+the following command in the ServiceMix console:
+
+  log:display

--- a/examples/camel/camel-drools-blueprint/pom.xml
+++ b/examples/camel/camel-drools-blueprint/pom.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <!--
+
+       Licensed to the Apache Software Foundation (ASF) under one or more
+       contributor license agreements.  See the NOTICE file distributed with
+       this work for additional information regarding copyright ownership.
+       The ASF licenses this file to You under the Apache License, Version 2.0
+       (the "License"); you may not use this file except in compliance with
+       the License.  You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+   -->
+
+    <parent>
+        <artifactId>camel-examples</artifactId>
+        <groupId>org.apache.servicemix.examples</groupId>
+        <version>5.0.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>camel-drools-blueprint</artifactId>
+    <packaging>bundle</packaging>
+    <name>Apache ServiceMix :: Examples :: Camel Drools Blueprint</name>
+    <description>Camel Example using Drools and Blueprint</description>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Import-Package>*</Import-Package>
+                        <Export-package>org.apache.servicemix.examples.camel</Export-package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.drools</groupId>
+            <artifactId>drools-core</artifactId>
+            <version>${drools.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.drools</groupId>
+            <artifactId>drools-spring</artifactId>
+            <version>${drools.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>spring-core</artifactId>
+                    <groupId>org.springframework</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>spring-beans</artifactId>
+                    <groupId>org.springframework</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>spring-context</artifactId>
+                    <groupId>org.springframework</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.drools</groupId>
+            <artifactId>drools-camel</artifactId>
+            <version>${drools.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>spring-core</artifactId>
+                    <groupId>org.springframework</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>spring-aop</artifactId>
+                    <groupId>org.springframework</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>cxf-rt-frontend-jaxws</artifactId>
+                    <groupId>org.apache.cxf</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>camel-cxf</artifactId>
+                    <groupId>org.apache.camel</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>org.apache.camel</artifactId>
+                    <groupId>camel-test</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+
+</project>

--- a/examples/camel/camel-drools-blueprint/src/main/java/org/apache/servicemix/examples/camel/Drinks.java
+++ b/examples/camel/camel-drools-blueprint/src/main/java/org/apache/servicemix/examples/camel/Drinks.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.servicemix.examples.camel;
+
+public enum Drinks {
+    WATER("glass of water"),
+    COLA_ZERO("bottle of Cola Zero"),
+    COLA_LIGHT("bottle of Cola Light with a straw"),
+    WINE("glass of wine"),
+    BEER("pint of beer"),
+    SCOTCH("good old scotch"),
+    CHAMPAGNE("bottle of champagne");
+
+    private String description;
+
+    private Drinks(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}
+

--- a/examples/camel/camel-drools-blueprint/src/main/java/org/apache/servicemix/examples/camel/DroolsBlueprintBean.java
+++ b/examples/camel/camel-drools-blueprint/src/main/java/org/apache/servicemix/examples/camel/DroolsBlueprintBean.java
@@ -1,0 +1,93 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.servicemix.examples.camel;
+
+import org.drools.KnowledgeBase;
+import org.drools.KnowledgeBaseConfiguration;
+import org.drools.KnowledgeBaseFactory;
+import org.drools.KnowledgeBaseFactoryService;
+import org.drools.builder.KnowledgeBuilder;
+import org.drools.builder.KnowledgeBuilderErrors;
+import org.drools.builder.KnowledgeBuilderFactory;
+import org.drools.builder.KnowledgeBuilderFactoryService;
+import org.drools.compiler.PackageBuilderConfiguration;
+import org.drools.grid.Grid;
+import org.drools.grid.GridNode;
+import org.drools.grid.impl.GridImpl;
+import org.drools.grid.impl.GridNodeImpl;
+import org.drools.io.ResourceFactory;
+import org.drools.io.Resource;
+import org.drools.builder.ResourceType;
+import org.drools.runtime.CommandExecutor;
+
+import java.util.HashMap;
+
+public class DroolsBlueprintBean {
+
+
+    public static GridNode createGridNode(String id){
+        Grid grid = new GridImpl( new HashMap<String, Object>() );
+        return grid.createGridNode( id );
+    }
+
+    public static KnowledgeBase createKnowledgeBase(GridNode node,String resource,String resourcetype){
+
+        if ( node == null ) {
+            node = new GridNodeImpl();
+        }
+
+        //kbase configuration
+        PackageBuilderConfiguration kconf = (PackageBuilderConfiguration) KnowledgeBuilderFactory.newKnowledgeBuilderConfiguration(null,DroolsBlueprintBean.class.getClassLoader());
+
+        //kbuilder
+        KnowledgeBuilder kbuilder = node.get( KnowledgeBuilderFactoryService.class ).newKnowledgeBuilder( kconf);
+        kbuilder.add(parseResource(resource),ResourceType.getResourceType(resourcetype));
+
+        // error handling
+        KnowledgeBuilderErrors errors = kbuilder.getErrors();
+        if ( !errors.isEmpty() ) {
+            throw new RuntimeException( errors.toString() );
+        }
+
+        //KnowledgeBase
+        KnowledgeBaseConfiguration kbaseConfig = KnowledgeBaseFactory.newKnowledgeBaseConfiguration(null, DroolsBlueprintBean.class.getClassLoader());
+        KnowledgeBase kbase = node.get( KnowledgeBaseFactoryService.class ).newKnowledgeBase(kbaseConfig);
+        kbase.addKnowledgePackages( kbuilder.getKnowledgePackages() );
+
+        return kbase;
+    }
+
+    public static CommandExecutor createKnowledgeSession(KnowledgeBase kbase,GridNode node,String type,String name){
+        CommandExecutor ksession;
+
+        if (type.equals("stateful"))
+            ksession = kbase.newStatefulKnowledgeSession();
+        else
+            ksession = kbase.newStatelessKnowledgeSession();
+
+        node.set(name,ksession);
+        return ksession;
+    }
+
+    private static Resource parseResource(String resource) {
+        if ( resource.trim().startsWith( "classpath:" ) ) {
+            return  ResourceFactory.newClassPathResource(resource.substring( resource.indexOf( ':' ) + 1 ),DroolsBlueprintBean.class);
+        } else {
+            return ResourceFactory.newUrlResource( resource );
+        }
+    }
+}

--- a/examples/camel/camel-drools-blueprint/src/main/java/org/apache/servicemix/examples/camel/DroolsCommandHelper.java
+++ b/examples/camel/camel-drools-blueprint/src/main/java/org/apache/servicemix/examples/camel/DroolsCommandHelper.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicemix.examples.camel;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.drools.command.impl.GenericCommand;
+import org.drools.command.runtime.BatchExecutionCommandImpl;
+import org.drools.command.runtime.rule.FireAllRulesCommand;
+import org.drools.command.runtime.rule.InsertObjectCommand;
+
+import java.util.List;
+
+/**
+ * Class to help create wrapper Drools Expert Command for use with
+ * org.drools/drools-camel component.
+ */
+public class DroolsCommandHelper {
+	public void insertAndFireAll(Exchange exchange) {
+		final Message in = exchange.getIn();
+		final Object body = in.getBody();
+
+		// TODO: add type checking to handle arrays of objects
+
+		BatchExecutionCommandImpl command = new BatchExecutionCommandImpl();
+		final List<GenericCommand<?>> commands = command.getCommands();
+		commands.add(new InsertObjectCommand(body, "obj1"));
+		commands.add(new FireAllRulesCommand());
+
+		in.setBody(command);
+	}
+
+	// TODO: add other command handler methods (e.g. getGlobalObject, etc.)
+}

--- a/examples/camel/camel-drools-blueprint/src/main/java/org/apache/servicemix/examples/camel/Person.java
+++ b/examples/camel/camel-drools-blueprint/src/main/java/org/apache/servicemix/examples/camel/Person.java
@@ -1,0 +1,119 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.servicemix.examples.camel;
+
+import org.drools.definition.type.PropertyReactive;
+
+@PropertyReactive
+public class Person {
+	private int age;
+	private boolean canDrink = false;
+    private Sex sex;
+    private int income;
+    private boolean isVip = false;
+    private Drinks drink;
+
+	public int getAge() {
+		return age;
+	}
+
+    public void setAge(int age) {
+        this.age = age;
+    }
+
+    public int getIncome() {
+        return income;
+    }
+
+    public void setIncome(int income) {
+        this.income = income;
+    }
+
+    public Sex getSex() {
+        return sex;
+    }
+
+    public void setSex(Sex sex) {
+        this.sex = sex;
+    }
+
+	public boolean isCanDrink() {
+		return canDrink;
+	}
+
+	public void setCanDrink(boolean canDrink) {
+		this.canDrink = canDrink;
+	}
+
+    public boolean isVip() {
+        return isVip;
+    }
+
+    public void setVip(boolean vip) {
+        isVip = vip;
+    }
+
+    public Drinks getDrink() {
+        return drink;
+    }
+
+    public void setDrink(Drinks drink) {
+        this.drink = drink;
+    }
+
+    public boolean isRich(){
+        return getIncome() >= 80000;
+    }
+
+    public String getName() {
+        StringBuilder name = new StringBuilder();
+
+        // Age
+        if (getAge()>=21){
+            name.append("old");
+        }else{
+            name.append("young");
+        }
+
+        //Income
+        if (isRich()){
+            name.append(" rich");
+        }
+
+        //Sex
+        if (getSex() == Sex.MALE){
+            name.append(" man");
+        }else{
+             name.append(" woman");
+        }
+
+        return name.toString();
+    }
+
+    @Override
+    public String toString() {
+        return "Person{" +
+                "age=" + age +
+                ", canDrink=" + canDrink +
+                ", sex=" + sex +
+                ", income=" + getIncome() +
+                ", isRich=" + isRich() +
+                ", isVip=" + isVip +
+                ", drink=" + drink +
+                '}';
+    }
+}

--- a/examples/camel/camel-drools-blueprint/src/main/java/org/apache/servicemix/examples/camel/PersonHelper.java
+++ b/examples/camel/camel-drools-blueprint/src/main/java/org/apache/servicemix/examples/camel/PersonHelper.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicemix.examples.camel;
+
+import java.util.Random;
+
+public class PersonHelper {
+	private final Random random = new Random();
+
+	public Person createTestPerson() {
+		Person person = new Person();
+
+		// Age
+		person.setAge(random.nextInt(70));
+
+        // Sex
+        if (random.nextBoolean()) {
+            person.setSex(Sex.MALE);
+        } else {
+            person.setSex(Sex.FEMALE);
+        }
+
+        // Income
+        person.setIncome(random.nextInt(100000));
+
+        return person;
+	}
+
+}

--- a/examples/camel/camel-drools-blueprint/src/main/java/org/apache/servicemix/examples/camel/Sex.java
+++ b/examples/camel/camel-drools-blueprint/src/main/java/org/apache/servicemix/examples/camel/Sex.java
@@ -1,0 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicemix.examples.camel;
+
+public enum Sex {
+    MALE, FEMALE
+}

--- a/examples/camel/camel-drools-blueprint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/examples/camel/camel-drools-blueprint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<blueprint
+        xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd">
+
+   <!--
+   We use the DroolsBlueprintBean to replace the grid-node element from the Drools Spring namespace handler:
+
+   Spring example:
+
+   <drools:grid-node id="node1"/>
+   -->
+   <bean id="node1"
+         class="org.apache.servicemix.examples.camel.DroolsBlueprintBean"
+         factory-method="createGridNode">
+       <argument value="node1"/>
+   </bean>
+
+
+   <!--
+   We use the DroolsBlueprintBean to replace the kbase element from the Drools Spring namespace handler:
+
+   Spring example:
+
+   <drools:kbase id="kbase1" node="node1">
+        <drools:resources>
+            <drools:resource type="DRL" source="classpath:testSpring.drl"/>
+        </drools:resources>
+    </drools:kbase>
+   -->
+   <bean id="kbase1"
+         class="org.apache.servicemix.examples.camel.DroolsBlueprintBean"
+         factory-method="createKnowledgeBase">
+       <argument ref="node1"/>
+       <argument value="classpath:testSpring.drl" />
+       <argument value="DRL" />
+   </bean>
+
+    <!--
+   We use the DroolsBlueprintBean to replace the ksession element from the Drools Spring namespace handler:
+
+   Spring example:
+
+   <drools:ksession id="ksession1" type="stateless" name="ksession1" kbase="kbase1" node="node1"/>
+   -->
+   <bean id="ksession1"
+         class="org.apache.servicemix.examples.camel.DroolsBlueprintBean"
+         factory-method="createKnowledgeSession">
+       <argument ref="kbase1"/>
+       <argument ref="node1"/>
+       <argument value="stateless"/>
+       <argument value="ksession1"/>
+   </bean>
+
+
+   <bean id="droolsHelper" class="org.apache.servicemix.examples.camel.DroolsCommandHelper"/>
+
+   <bean id="personHelper" class="org.apache.servicemix.examples.camel.PersonHelper"/>
+
+   <!-- declare the drools bean here to avoid OSGi classpath issues -->
+    <bean id="drools" class="org.drools.camel.component.DroolsComponent" depends-on="ksession1"/>
+
+    <camelContext xmlns="http://camel.apache.org/schema/blueprint" >
+        <route trace="false" id="testRoute">
+            <description>
+                Example route that will regularly create a random Person and choose an appropriate drink based on the
+                drools rules file. After processing, it divides the people into VIPs and regular clients based on the
+                drools result.
+            </description>
+            <from uri="timer:testRoute"/>
+            <bean method="createTestPerson" ref="personHelper"/>
+            <to uri="drools:node1/ksession1?action=insertBody" id="DrinkChooser">
+                <description>valid 'action' values are:
+                    'execute' that takes a 'Command' object (default)
+                    'insertBody' that inserts the Exchange.in.body, and executes rules
+                    'insertMessage' that inserts the Exchange.in (type org.apache.camel.Message), and executes rules
+                    'insertExchange' that inserts the Exchange (type org.apache.camel.Exchange), and executes rules
+                </description>
+            </to>
+            <choice>
+                <when id="Vip">
+                    <simple>${body.isVip}</simple>
+                    <log logName="ServeDrink VIP" message="This ${body.name} is a VIP! Give a ${body.getDrink.getDescription} from the house"/>
+                </when>
+                <otherwise>
+                    <log logName="ServeDrink" message="Serve this ${body.name} a ${body.getDrink.getDescription}"/>
+                </otherwise>
+            </choice>
+        </route>
+    </camelContext>
+
+</blueprint>

--- a/examples/camel/camel-drools-blueprint/src/main/resources/log4j.properties
+++ b/examples/camel/camel-drools-blueprint/src/main/resources/log4j.properties
@@ -1,0 +1,35 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# The logging properties used
+#
+log4j.rootLogger=INFO, out
+
+# uncomment the following line to turn on Camel debugging
+#log4j.logger.org.apache.camel=DEBUG
+
+log4j.logger.org.springframework=WARN
+
+
+# CONSOLE appender not used by default
+log4j.appender.out=org.apache.log4j.ConsoleAppender
+log4j.appender.out.layout=org.apache.log4j.PatternLayout
+log4j.appender.out.layout.ConversionPattern=[%30.30t] %-30.30c{1} %-5p %m%n
+#log4j.appender.out.layout.ConversionPattern=%d [%-15.15t] %-5p %-30.30c{1} - %m%n
+
+log4j.throwableRenderer=org.apache.log4j.EnhancedThrowableRenderer

--- a/examples/camel/camel-drools-blueprint/src/main/resources/testSpring.drl
+++ b/examples/camel/camel-drools-blueprint/src/main/resources/testSpring.drl
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicemix.examples.camel;
+
+import org.apache.servicemix.examples.camel.Person;
+import org.apache.servicemix.examples.camel.Sex;
+import org.apache.servicemix.examples.camel.Drinks;
+
+
+# no alcohol
+
+rule "humans need water"
+salience 2
+when
+    p : Person()
+then
+    modify(p) {setDrink(Drinks.WATER)};
+end
+
+rule "boys go for Cola Zero"
+salience 1
+when
+    p : Person(age >= 8 && sex == Sex.MALE)
+then
+    modify(p) {setDrink(Drinks.COLA_ZERO)};
+end
+
+rule "girls go for Cola Light"
+salience 1
+when
+    p : Person(age >= 8 && sex == Sex.FEMALE)
+then
+	modify(p) {setDrink(Drinks.COLA_LIGHT)};
+end
+
+
+#alcohol
+
+rule "can you drink?" 
+when
+    p : Person( age >= 21 && !canDrink)
+then
+	modify(p) {setCanDrink(true)};
+end
+
+rule "woman go for wine"
+when
+    p : Person(sex == Sex.FEMALE && canDrink )
+then
+	modify(p) {setDrink(Drinks.WINE)};
+end
+
+rule "men go for beer"
+when
+    p : Person(sex == Sex.MALE && canDrink )
+then
+	modify(p) {setDrink(Drinks.BEER)};
+end
+
+
+# VIP
+
+rule "Vip in the house!"
+salience -1
+when
+    p : Person( rich && !Vip)
+then
+    modify(p) {setVip(true)};
+end
+
+rule "Vip woman drink bubbles"
+when
+    p : Person(Vip && sex == Sex.FEMALE && canDrink)
+then
+	modify(p) {setDrink(Drinks.CHAMPAGNE)};
+end
+
+rule "Vip men drink Scotch"
+when
+    p : Person(Vip && sex == Sex.MALE && canDrink)
+then
+	modify(p) {setDrink(Drinks.SCOTCH)};
+end

--- a/examples/camel/pom.xml
+++ b/examples/camel/pom.xml
@@ -36,6 +36,7 @@
         <module>camel-blueprint</module>
         <module>camel-osgi</module>
         <module>camel-drools</module>
+        <module>camel-drools-blueprint</module>
     </modules>
 
 </project>


### PR DESCRIPTION
Clone of the camel-drools example but added a bean to take care of (a part of) the missing drools namespace handler for Blueprint.
